### PR TITLE
Add ability to specify drive and drive format to mender-qemu.

### DIFF
--- a/scripts/mender-qemu
+++ b/scripts/mender-qemu
@@ -6,16 +6,69 @@
 #           serial console: stdio
 
 set -e
-set -x
 
 BUILDDIR="`dirname $0`"/../../build
+
+usage() {
+    cat <<EOF
+$0 [options]
+
+-drive <image-file>
+	Which image file to use. If the path is relative, it will be relative
+	to the Yocto image location.
+-drive-fmt <image-format>
+	Format of the image, generally either 'raw' or 'qcow2'.
+EOF
+}
+
+while [ -n "$1" ]; do
+    case "$1" in
+        -h|-help|--help)
+            usage
+            exit 1
+            ;;
+
+        -drive|-drive=*)
+            opt="${1#-drive=}"
+            if [ "$opt" = "$1" ]; then
+                shift
+                opt="$1"
+            fi
+            DRIVE="$opt"
+            ;;
+
+        -drive-fmt|-drive-fmt=*)
+            opt="${1#-drive-fmt=}"
+            if [ "$opt" = "$1" ]; then
+                shift
+                opt="$1"
+            fi
+            DRIVE_FMT="$opt"
+            ;;
+    esac
+    shift
+done
+
+DRIVE=${DRIVE:-core-image-full-cmdline-vexpress-qemu.sdimg}
+DRIVE_FMT=${DRIVE_FMT:-raw}
+
+case "$DRIVE" in
+    /*)
+        FINAL_DRIVE="$DRIVE"
+        ;;
+    *)
+        FINAL_DRIVE="${BUILDDIR}/tmp/deploy/images/vexpress-qemu/$DRIVE"
+        ;;
+esac
+
+set -x
 
 QEMU_AUDIO_DRV=none \
     ${BUILDDIR}/tmp/sysroots/x86_64-linux/usr/bin/qemu-system-arm \
     -M vexpress-a9 \
     -m 1G \
     -kernel ${BUILDDIR}/tmp/deploy/images/vexpress-qemu/u-boot.elf \
-    -drive file=${BUILDDIR}/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.sdimg,if=sd,format=raw \
+    -drive file=${FINAL_DRIVE},if=sd,format=${DRIVE_FMT} \
     -net nic \
     -net user,hostfwd=tcp::8822-:22 \
     -display vnc=:23 \


### PR DESCRIPTION
This will be important to do testing, since testing will use a
revertible qcow2 image.