### PR TITLE
MEN-50: Implement data partition.

### DIFF
--- a/classes/sdimg.bbclass
+++ b/classes/sdimg.bbclass
@@ -13,9 +13,10 @@
 ##########                       values in your local.conf
 
 
-# Total size of the SD card. The two rootfs partition sizes are
-# auto-determined to fill the space of the SD card.
-SDIMG_SIZE_MB ?= "1000"
+# Optional location where a directory can be specified with content that should
+# be included on the data partition. Some of Mender's own files will be added to
+# this (e.g. OpenSSL certificates).
+SDIMG_DATA_PART_DIR ?= ""
 
 # Size of the first (FAT) partition, that contains the bootloader
 SDIMG_PART1_SIZE_MB ?= "128"
@@ -33,116 +34,65 @@ SDIMG_PARTITION_ALIGNMENT_MB ?= "8"
 
 ########## CONFIGURATION END ##########
 
+inherit image_types
 
-# This script depends on:
-#     util-linux (fdisk)
-#     dosfstools (mkfs.vfat)
-#     mtools     (mcopy)
-#     e2fsprogs  (resize2fs)
-IMAGE_DEPENDS_sdimg = "util-linux-native dosfstools-native mtools-native e2fsprogs-native"
+WKS_FULL_PATH = "${WORKDIR}/mender-sdimg.wks"
 
 # We need to have the ext3 image generated already
 IMAGE_TYPEDEP_sdimg = "ext3"
 
+IMAGE_DEPENDS_sdimg = "${IMAGE_DEPENDS_wic}"
 
-IMAGE_CMD_sdimg () {
+IMAGE_CMD_sdimg() {
+    mkdir -p "${WORKDIR}"
 
-    set -x                                      # debug output
-    set -e                                      # exit on error
-    set -u                                      # exit on unset variable
-    # Needs bash, TODO can I require that this runs under bash?
-    # set -o pipefail                             # don't hide pipeline errors
+    # Workaround for the fact that the image builder requires this directory,
+    # despite not using it. If "rm_work" is enabled, this directory won't always
+    # exist.
+    mkdir -p "${IMAGE_ROOTFS}"
 
-    cd ${DEPLOY_DIR_IMAGE}
-    ROOTFS_IMG=${IMAGE_NAME}.rootfs.ext3
-    SDIMG=${IMAGE_NAME}.rootfs.sdimg
+    # Workaround for the fact the wic deletes its inputs (WTF??). These links
+    # are disposable.
+    ln -sfn "${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.ext3" \
+        "${WORKDIR}/part1.tmp"
+    ln -sfn "${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.ext3" \
+        "${WORKDIR}/part2.tmp"
 
-    # Assert rootfs has been correctly generated
-    test -e ${ROOTFS_IMG}
-
-    # Compute partition borders and sizes, EVERYTHING IN SECTORS (512 bytes)
-
-    SDIMG_SIZE_SECTORS=$(expr ${SDIMG_SIZE_MB} \* 2048)
     PART1_SIZE=$(expr ${SDIMG_PART1_SIZE_MB} \* 2048)
+    SDIMG_PARTITION_ALIGNMENT_KB=$(expr ${SDIMG_PARTITION_ALIGNMENT_MB} \* 1024)
 
-    ALIGNMENT=$(expr ${SDIMG_PARTITION_ALIGNMENT_MB} \* 2048)
-    PART1_START=${ALIGNMENT}
-    PART1_END=$(expr ${PART1_START} + ${PART1_SIZE} - 1)
-    PART2_START=$(expr \( 1 + ${PART1_END} / ${ALIGNMENT} \) \* ${ALIGNMENT})
-    PART23_SIZE_UNALIGNED=$(expr \( ${SDIMG_SIZE_SECTORS} - ${PART2_START} \) / 2)
-    PART23_SIZE=$(expr ${PART23_SIZE_UNALIGNED} - ${PART23_SIZE_UNALIGNED} % ${ALIGNMENT})
-    PART2_END=$(expr ${PART2_START} + ${PART23_SIZE} - 1)
-    PART3_START=$(expr \( 1 + ${PART2_END} / ${ALIGNMENT} \) \* ${ALIGNMENT})
-    PART3_END=$(expr ${PART3_START} + ${PART23_SIZE} - 1)
-
-    # Assert we are not past the limits of the SD card size
-    test ${PART3_END} -lt ${SDIMG_SIZE_SECTORS}
-
-    # Resize rootfs to be as big as the partitions 2 and 3
-    resize2fs ${ROOTFS_IMG} ${PART23_SIZE}s
-
-    # Assert that the rootfs size is smaller than PART23_SIZE
-    ROOTFS_SIZE=$(wc -c ${ROOTFS_IMG} | cut -d\  -f1 )
-    test ${ROOTFS_SIZE} -le $(expr ${PART23_SIZE} \* 512)
-
-    dd if=/dev/zero of=${SDIMG} count=0 seek=${SDIMG_SIZE_SECTORS}
-    export PART1_START PART1_END PART2_START PART2_END PART3_START PART3_END
-    (
-        # Create DOS partition table
-        echo o
-        # 1st partition (FAT32)
-        echo n
-        echo p
-        echo 1
-        echo ${PART1_START}
-        echo ${PART1_END}
-        # 2nd partition (1st rootfs)
-        echo n
-        echo p
-        echo 2
-        echo ${PART2_START}
-        echo ${PART2_END}
-        # 3rd partition (2nd root)
-        echo n
-        echo p
-        echo 3
-        echo ${PART3_START}
-        echo ${PART3_END}
-        # 1st partition: bootable
-        echo a
-        echo 1
-        # 1st partition: type W95 FAT16 (LBA)
-        echo t
-        echo 1
-        echo e
-        # 2nd partition: type Linux
-        echo t
-        echo 2
-        echo 83
-        # 3rd partition: type Linux
-        echo t
-        echo 3
-        echo 83
-        # COMMIT changes to image file
-        echo p
-        echo w
-
-    ) | fdisk --compatibility=nondos --units=sectors ${SDIMG}
-
-    dd if=/dev/zero of=fat.dat count=${PART1_SIZE}
-    mkfs.vfat fat.dat
+    dd if=/dev/zero of="${WORKDIR}/fat.dat" count=${PART1_SIZE}
+    mkfs.vfat "${WORKDIR}/fat.dat"
 
     # Create empty environment. Just so that the file is available.
-    dd if=/dev/zero of=uboot.env count=0 bs=1K seek=256
-    mcopy -i fat.dat -v uboot.env ::
-    rm -f uboot.env
+    dd if=/dev/zero of="${WORKDIR}/uboot.env" count=0 bs=1K seek=256
+    mcopy -i "${WORKDIR}/fat.dat" -v "${WORKDIR}/uboot.env" ::
+    rm -f "${WORKDIR}/uboot.env"
 
-    dd if=fat.dat of=${SDIMG} seek=${PART1_START} conv=notrunc
-    rm -f fat.dat
+    rmdir "${WORKDIR}/data" || true
+    if [ -n "${SDIMG_DATA_PART_DIR}" ]; then
+        cp -a "${SDIMG_DATA_PART_DIR}" "${WORKDIR}/data"
+    else
+        mkdir -p "${WORKDIR}/data"
+    fi
 
-    dd if=${ROOTFS_IMG} of=${SDIMG} seek=${PART2_START} conv=notrunc
-    dd if=${ROOTFS_IMG} of=${SDIMG} seek=${PART3_START} conv=notrunc
+    # The OpenSSL certificates should go here:
+    echo "dummy certificate" > "${WORKDIR}/data/mender.cert"
 
-    # Print partition table, assert partitions are aligned and as expected
-    #TODO
+    cat > "${WORKDIR}/mender-sdimg.wks" <<EOF
+part /u-boot --source fsimage --sourceparams=file="${WORKDIR}/fat.dat"   --ondisk mmcblk0 --fstype=vfat --label u-boot   --align $SDIMG_PARTITION_ALIGNMENT_KB
+part /       --source fsimage --sourceparams=file="${WORKDIR}/part1.tmp" --ondisk mmcblk0 --fstype=ext3 --label platform --align $SDIMG_PARTITION_ALIGNMENT_KB
+part /       --source fsimage --sourceparams=file="${WORKDIR}/part2.tmp" --ondisk mmcblk0 --fstype=ext3 --label platform --align $SDIMG_PARTITION_ALIGNMENT_KB
+part /data   --source rootfs  --rootfs-dir="${WORKDIR}/data"             --ondisk mmcblk0 --fstype=ext3 --label data     --align $SDIMG_PARTITION_ALIGNMENT_KB
+
+# Note: "bootloader" appears to be useless in this context, but the wic
+# framework requires that it be present.
+bootloader --timeout=10  --append=""
+EOF
+
+    # Call WIC
+    IMAGE_CMD_wic
+
+    mv "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.rootfs.wic" "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.sdimg"
+    ln -sfn "${IMAGE_NAME}.sdimg" "${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.sdimg"
 }

--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -6,3 +6,4 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # Where the U-Boot environment resides.
 /dev/mmcblk0p1       /u-boot              auto       defaults,sync,auto    0  0
+/dev/mmcblk0p5       /data                auto       defaults,auto         0  0

--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 do_install_append () {
     install -d ${D}/u-boot
+    install -d ${D}/data
 }


### PR DESCRIPTION
This will be used by Mender certificates as well as other files that
the image builder wishes to store somewhere else than on the root
filsystem.

Also get rid of custom partition script, and use the standard Yocto
tool, wic, to do the job.