### PR TITLE
Fix Jenkins build the wrong revision.

### DIFF
--- a/build-conf/local.conf
+++ b/build-conf/local.conf
@@ -239,3 +239,10 @@ ASSUME_PROVIDED += "libsdl-native"
 # track the version of this file when it was generated. This can safely be ignored if
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
+
+# In order to build from the repository that Jenkins has cloned, instead of
+# letting bitbake pull the sources, we use "externalsrc".
+INHERIT += "externalsrc"
+# Final variable will be written by Jenkins recipe, since it contains an
+# environment variable (bitbake cannot accept those directly).
+#EXTERNALSRC_pn-mender = "${WORKSPACE}/mender"


### PR DESCRIPTION
The problem is that AUTOREV which is used in the Mender recipe is not
checked for an updated revision if nothing else has changed in the
meta-mender repository, which is something we need. So instead, we let
Jenkins clone an updated version.

The fix is threefold:

- The fix in this commit, which enables building from an external
  source (where Jenkins has pre-cloned the repo).
- Adding the cloning of the mender repository to Jenkins.
- Making sure that the location of the mender repository is appended
  to the local.conf file in the Jenkins recipe, since we cannot refer
  to the Jenkins environment variables directly from bitbake.